### PR TITLE
Feat/home api integration

### DIFF
--- a/src/components/ProductCard/index.tsx
+++ b/src/components/ProductCard/index.tsx
@@ -16,27 +16,28 @@ import {
 
 type ProductCardProps = {
   id: string;
-  imageURL?: string;
-  category: string;
-  title: string;
+  imageURL?: string[];
+  collectionName: string;
+  name: string;
   price: number;
+  quantity: number;
 };
 
 const ProductCard: React.FC<ProductCardProps> = ({
   id,
-  imageURL,
-  category,
-  title,
+  imageURL = [],
+  collectionName,
+  name,
   price,
 }) => (
   <Wrapper>
     <ImageWrapper to={`product&id=${id}`}>
-      <Img imageURL={imageURL} />
+      <Img imageURL={imageURL[0]} />
     </ImageWrapper>
     <InformationWrapper>
       <InformationList to={`product&id=${id}`}>
-        <Category>{category}</Category>
-        <Title>{title}</Title>
+        <Category>{collectionName}</Category>
+        <Title>{name}</Title>
         <Price>{`R$${price}`}</Price>
       </InformationList>
       <AddCartWrapper>

--- a/src/components/ProductCarrousel/index.tsx
+++ b/src/components/ProductCarrousel/index.tsx
@@ -2,49 +2,29 @@ import React from 'react';
 import { ProductCard } from '..';
 import { CarrouselWrapper, ItemWrapper, Wrapper } from './styles';
 
-interface Product {
-  id: string;
-  imageURL?: string;
-  category: string;
-  title: string;
-  price: number;
-}
+type ProductCarrouselProps = {
+  products: Product[];
+};
 
-const defaultProducts: Product[] = [
-  {
-    id: '5123',
-    imageURL:
-      'https://www.extra-imagens.com.br/Control/ArquivoExibir.aspx?IdArquivo=887253487',
-    category: 'NEW',
-    title: 'Hotwheels Nissan 350z Preto',
-    price: 9.99,
-  },
-  {
-    id: '61123',
-    imageURL:
-      'https://images-na.ssl-images-amazon.com/images/I/61ZTdXGjRYL._AC_SY450_.jpg',
-    category: 'ELECTRONICS',
-    title: 'Teclado Mecânico Bright',
-    price: 239.49,
-  },
-  {
-    id: '5123',
-    imageURL:
-      'https://a-static.mlcdn.com.br/1500x1500/iphone-12-apple-128gb-azul-tela-61-cam-dupla-12mp-ios/magazineluiza/155598400/6b9b8ece04de165ab19587f5bd491df4.jpg',
-    category: 'ELECTRONICS',
-    title: 'iPhone 12 Apple 128GB Azul Tela 6,1',
-    price: 4719.19,
-  },
-];
-
-const ProductCarrousel: React.FC = () => (
+const ProductCarrousel: React.FC<ProductCarrouselProps> = ({ products }) => (
   <Wrapper>
     <CarrouselWrapper>
-      {defaultProducts.map(({ category, title, id, imageURL, price }) => (
-        <ItemWrapper>
-          <ProductCard {...{ category, title, id, imageURL, price }} />
-        </ItemWrapper>
-      ))}
+      {products.map(
+        ({ id, name, price, trending, collection, images, quantity }) =>
+          trending ? (
+            <ItemWrapper>
+              <ProductCard
+                key={id}
+                id={id}
+                price={price}
+                collectionName={collection.name}
+                name={name}
+                imageURL={images}
+                quantity={quantity}
+              />
+            </ItemWrapper>
+          ) : null,
+      )}
     </CarrouselWrapper>
   </Wrapper>
 );

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,5 +1,4 @@
-// import React, { useEffect, useState } from 'react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Banner,
   Categories,
@@ -7,35 +6,26 @@ import {
   ProductCarrousel,
   Header,
 } from '../../components';
-// import api from '../../services/api';
+import api from '../../services/api';
 import { Wrapper } from './styles';
 
-// interface Product {
-//   name: string;
-//   price: number;
-//   collection: {
-//     id: string;
-//     name: string;
-//   };
-// }
-
 const Home: React.FC = () => {
-  // const [products, setProducts] = useState<Product[]>([]);
+  const [products, setProducts] = useState<Product[]>([]);
 
-  // useEffect(() => {
-  //   async function getDataProducts() {
-  //     const response = await api.get<Product[]>('/public/products/trends');
-  //     setProducts(response.data);
-  //   }
+  useEffect(() => {
+    async function getDataProducts() {
+      const response = await api.get<Product[]>('/public/products/trends');
+      setProducts(response.data);
+    }
 
-  //   getDataProducts();
-  // }, []);
+    getDataProducts();
+  }, []);
   return (
     <Wrapper>
       <Header />
       <Categories />
       <Banner />
-      <ProductCarrousel />
+      <ProductCarrousel products={products} />
       <Footer />
     </Wrapper>
   );

--- a/src/utils/types/Product.d.ts
+++ b/src/utils/types/Product.d.ts
@@ -1,0 +1,12 @@
+declare type Product = {
+  id: string;
+  name: string;
+  price: number;
+  trending: boolean;
+  collection: {
+    id: string;
+    name: string;
+  };
+  images: string[];
+  quantity: number;
+};


### PR DESCRIPTION
## O que foi feito?

<!-- explique de maneira breve e objetiva o que foi feito nessa PR -->
Integração com a API, puxando agora as informações sobre os produtos *trending* na Home. Pra isso precisei alterar:
 * types -> definição da tipagem usando *declare type*;
 * ProductCard/ProductCarrousel/Home -> alteração de nome e tipagem para ficar igual ao back-end;

## Link da task
https://www.notion.so/Homepage-1843958fa9d64d7195ac2de29d96366e
<!-- explique de maneira breve e objetiva o que foi feito nessa PR -->

## Prints/GIFs/Vídeos
![image](https://user-images.githubusercontent.com/61251953/111987649-3ae70400-8aee-11eb-8258-fd035442be98.png)

<!-- Demonstrações da funcionalidade -->

## Testando funcionalidade
> só dar um `yarn start` e já vai dar para ver os produtos sendo puxados da API.
<!-- Demonstrações da funcionalidade -->

## Problemas?
> nenhum! :sunglasses: 
<!-- Demonstrações da funcionalidade -->

## Foi testado nos Navegadores

- [ ] Safari
- [x] Mozilla
- [x] Chrome
- [ ] Edge
